### PR TITLE
Switch to bleak for BLE communication

### DIFF
--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -8,7 +8,7 @@ import asyncio
 class Ooler:
     """Control an Ooler device via Bluetooth LE"""
 
-    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=1):
+    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=5):
         self.address = address
         self.stay_connected = stay_connected
         self.max_connection_attempts = max_connection_attempts

--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -8,7 +8,7 @@ import asyncio
 class Ooler:
     """Control an Ooler device via Bluetooth LE"""
 
-    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=5):
+    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=1):
         self.address = address
         self.stay_connected = stay_connected
         self.max_connection_attempts = max_connection_attempts

--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -1,7 +1,7 @@
 """Monitor and control an Ooler device via Bluetooth Low Energy"""
 import logging
-import ooler.constants as constants
-from gattlib import GATTRequester, BTIOException
+from ooler import constants
+from bleak import BleakClient, BleakError
 
 
 class Ooler:
@@ -11,70 +11,51 @@ class Ooler:
         self.address = address
         self.stay_connected = stay_connected
         self.max_connection_attempts = max_connection_attempts
-        self.requester = GATTRequester(address, False)
+        self.client = None
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
-        if self.stay_connected:
-            self.connect()
 
-    def connect(self) -> None:
+    async def connect(self) -> None:
         """Attempt to connect to the Ooler"""
-        if self.requester.is_connected():
+        if self.client and self.client.is_connected:
             return
 
-        for attempt in range(self.max_connection_attempts):
-            try:
-                self.logger.debug(f"Attempting to connect, attempt {attempt}")
-                self.requester.connect(True)
-                self.logger.info(f"Connected to {self.address}")
-                break
-            except BTIOException as exc:
-                self.logger.warning(
-                    f"Failed to connect on attempt {attempt}, got {exc}"
-                )
-                self.requester.disconnect()
+        self.client = BleakClient(self.address)
+        self.logger.info("Attempting to connect")
+        await self.client.connect()
+        self.logger.info(f"Connected to {self.address}")
 
-        if not self.requester.is_connected():
+
+        if not self.client.is_connected:
             raise ConnectionError(
-                f"Failed to connect after {self.max_connection_attempts} goes"
+                "Failed to connect to Ooler"
             )
 
-        self.requester.exchange_mtu(512)
-        self.uuid_map = self._get_uuid_map()
-
-    def _get_uuid_map(self) -> dict:
-        """
-        Get a mapping of UUIDs to handles - this shouldn't be needed, but the
-        UUID-related functions don't seem to work for me with the Ooler
-        """
-        characteristics = self.requester.discover_characteristics()
-        return {v["uuid"]: v["value_handle"] for v in characteristics}
-
-    def _request_characteristic(self, uuid: str) -> bytes:
+    async def _request_characteristic(self, uuid: str) -> bytes:
         """Request a characteristic, handling connections and the like"""
-        if not self.requester.is_connected():
-            self.connect()
+        if not self.client.is_connected:
+            await self.connect()
 
-        value = self.requester.read_by_handle(self.uuid_map[uuid])[0]
+        value = await self.client.read_gatt_char(uuid)
 
         if not self.stay_connected:
-            self.disconnect()
+            await self.disconnect()
 
         return value
 
-    def _write_characteristic(self, uuid: str, data: bytes) -> bytes:
+    async def _write_characteristic(self, uuid: str, data: bytes) -> bytes:
         """Write a characteristic, handling connections and the like"""
-        if not self.requester.is_connected():
+        if not self.client.is_connected:
             self.connect()
 
-        self.requester.write_by_handle(self.uuid_map[uuid], data)
+        await self.client.write_gatt_char(uuid, data)
 
         if not self.stay_connected:
             self.disconnect()
 
-    def disconnect(self) -> None:
+    async def disconnect(self) -> None:
         """Disconnect from the Ooler"""
-        self.requester.disconnect()
+        await self.client.disconnect()
 
     @staticmethod
     def _f_to_c(deg_f: int) -> int:
@@ -88,99 +69,83 @@ class Ooler:
         f_float = (deg_c * 1.8) + 32
         return round(f_float)
 
-    @property
-    def actual_temperature_f(self) -> int:
+    async def get_actual_temperature_f(self) -> int:
         """Get the current tempterature in Fahrenheit"""
         return int.from_bytes(
-            self._request_characteristic(constants.ACTUAL_TEMP_F), byteorder="big"
+            await self._request_characteristic(constants.ACTUAL_TEMP_F), byteorder="big"
         )
 
-    @property
-    def actual_temperature_c(self) -> int:
+    async def get_actual_temperature_c(self) -> int:
         """Get the current tempterature in Celsius"""
-        return self._f_to_c(self.actual_temperature_f)
+        return self._f_to_c(await self.get_actual_temperature_f())
 
-    @property
-    def desired_temperature_f(self) -> int:
+    async def get_desired_temperature_f(self) -> int:
         """Get the desired tempterature in Fahrenheit"""
         return int.from_bytes(
-            self._request_characteristic(constants.TARGET_TEMP_F), byteorder="big"
+            await self._request_characteristic(constants.TARGET_TEMP_F), byteorder="big"
         )
 
-    @desired_temperature_f.setter
-    def desired_temperature_f(self, deg_f: int) -> None:
+    async def set_desired_temperature_f(self, deg_f: int) -> None:
         """Set the desired tempterature in Fahrenheit"""
-        self._write_characteristic(
+        await self._write_characteristic(
             constants.TARGET_TEMP_F, deg_f.to_bytes(1, byteorder="big")
         )
 
-    @property
-    def desired_temperature_c(self) -> int:
+    async def get_desired_temperature_c(self) -> int:
         """Get the desired tempterature in Celsius"""
-        return self._f_to_c(self.desired_temperature_f)
+        return self._f_to_c(await self.get_desired_temperature_f())
 
-    @desired_temperature_c.setter
-    def desired_temperature_c(self, deg_c: int) -> None:
+    async def set_desired_temperature_c(self, deg_c: int) -> None:
         """Set the desired tempterature in Celsius"""
-        self.desired_temperature_f = self._c_to_f(deg_c)
+        await self.set_desired_temperature_f(self._c_to_f(deg_c))
 
-    @property
-    def powered_on(self) -> bool:
+    async def powered_on(self) -> bool:
         """Return the power state of the Ooler"""
-        return self._request_characteristic(constants.POWER_STATUS) == b"\x01"
+        return await self._request_characteristic(constants.POWER_STATUS) == b"\x01"
 
-    @powered_on.setter
-    def powered_on(self, value: bool) -> None:
+    async def set_power_state(self, value: bool) -> None:
         """Turn the Ooler on or off"""
-        self._write_characteristic(
+        await self._write_characteristic(
             constants.POWER_STATUS, value.to_bytes(1, byteorder="big")
         )
 
-    @property
-    def fan_speed(self) -> constants.FanSpeed:
+    async def get_fan_speed(self) -> constants.FanSpeed:
         """Return the fan mode of the Ooler"""
-        speed = self._request_characteristic(constants.FAN_SPEED)
+        speed = await self._request_characteristic(constants.FAN_SPEED)
         return constants.FanSpeed(int.from_bytes(speed, byteorder="big"))
 
-    @fan_speed.setter
-    def fan_speed(self, speed: constants.FanSpeed) -> None:
+    async def set_fan_speed(self, speed: constants.FanSpeed) -> None:
         """Return the fan mode of the Ooler"""
-        self._write_characteristic(
+        await self._write_characteristic(
             constants.FAN_SPEED, speed.value.to_bytes(1, byteorder="big")
         )
 
-    @property
-    def water_level(self) -> int:
+    async def get_water_level(self) -> int:
         """Return the water level of the Ooler"""
         return int.from_bytes(
-            self._request_characteristic(constants.WATER_LEVEL), byteorder="big"
+            await self._request_characteristic(constants.WATER_LEVEL), byteorder="big"
         )
 
-    @property
-    def pump_wattage(self) -> int:
+    async def get_pump_wattage(self) -> int:
         """Return the wattage of the pump"""
         return int.from_bytes(
-            self._request_characteristic(constants.PUMP_WATTS), byteorder="big"
+            await self._request_characteristic(constants.PUMP_WATTS), byteorder="big"
         )
 
-    @property
-    def pump_voltage(self) -> int:
+    async def get_pump_voltage(self) -> int:
         """Return the volttage of the pump"""
         return int.from_bytes(
-            self._request_characteristic(constants.PUMP_VOLTS), byteorder="big"
+            await self._request_characteristic(constants.PUMP_VOLTS), byteorder="big"
         )
 
-    @property
-    def cleaning(self) -> bool:
+    async def is_cleaning(self) -> bool:
         """Return whether the device is cleaning itself"""
-        return self._request_characteristic(constants.CLEAN) == b"\x01"
+        return await self._request_characteristic(constants.CLEAN) == b"\x01"
 
-    @cleaning.setter
-    def cleaning(self, value: bool) -> None:
+    async def set_cleaning(self, value: bool) -> None:
         """Tell the device to clean"""
-        self._write_characteristic(constants.CLEAN, value.to_bytes(1, byteorder="big"))
+        await self._write_characteristic(constants.CLEAN, value.to_bytes(1, byteorder="big"))
 
-    @property
-    def name(self) -> str:
+    async def get_name(self) -> str:
         """Get the name of the Ooler"""
-        return self._request_characteristic(constants.NAME).decode(encoding="ascii")
+        return (await self._request_characteristic(constants.NAME)).decode(encoding="ascii")

--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -38,7 +38,7 @@ class Ooler:
                     self.logger.info(f"Connected to {self.address}")
                 except BleakError as exc:
                     self.logger.warning(f"Failed to connect on attempt {attempt}, got {exc}")
-                    asyncio.sleep(self.connection_retry_interval)
+                    await asyncio.sleep(self.connection_retry_interval)
                 attempt = attempt + 1
 
             if not self.client.is_connected:

--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -2,17 +2,18 @@
 import logging
 from ooler import constants
 from bleak import BleakClient, BleakError
-import time
+import asyncio
 from threading import Lock
 
 
 class Ooler:
     """Control an Ooler device via Bluetooth LE"""
 
-    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30):
+    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=1):
         self.address = address
         self.stay_connected = stay_connected
         self.max_connection_attempts = max_connection_attempts
+        self.connection_retry_interval = connection_retry_interval
         self.client = BleakClient(self.address)
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
@@ -34,7 +35,7 @@ class Ooler:
                     self.logger.info(f"Connected to {self.address}")
                 except BleakError as exc:
                     self.logger.warning(f"Failed to connect on attempt {attempt}, got {exc}")
-                    time.sleep(1)
+                    asyncio.sleep(self.connection_retry_interval)
                 attempt = attempt + 1
 
             if not self.client.is_connected:

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -12,6 +12,7 @@ import ooler
 async def main():
     """Initiate and start the loop"""
     myooler = ooler.Ooler(address=config["ooler_mac"], stay_connected=True)
+    await myooler.connect()
 
     device_definition = {
         "connections": [("mac", myooler.address)],
@@ -22,7 +23,7 @@ async def main():
 
     cfg_payloads = {
         f"{config['homeassistant_prefix']}/climate/{sanitise_mac(myooler.address)}/config": {
-            "name": myooler.name,
+            "name": await myooler.get_name(),
             "mode_state_topic": f"ooler/{sanitise_mac(myooler.address)}/state",
             "mode_state_template": "{{ value_json.power }}",
             "current_temperature_topic": f"ooler/{sanitise_mac(myooler.address)}/state",
@@ -90,7 +91,7 @@ async def control_fan(mqtt: Client, myooler: ooler.Ooler) -> None:
     async with mqtt.filtered_messages(message_filter) as messages:
         async for message in messages:
             fan_speed = message.payload.decode()
-            myooler.fan_speed = constants.FanSpeed[fan_speed]
+            await myooler.set_fan_speed(constants.FanSpeed[fan_speed])
             await send_update(mqtt, myooler)
 
 
@@ -100,7 +101,7 @@ async def control_cleaning(mqtt: Client, myooler: ooler.Ooler) -> None:
     async with mqtt.filtered_messages(message_filter) as messages:
         async for message in messages:
             payload = message.payload.decode()
-            myooler.cleaning = payload == "True"
+            await myooler.set_cleaning(payload == "True")
             await send_update(mqtt, myooler)
 
 
@@ -110,7 +111,7 @@ async def control_temperature(mqtt: Client, myooler: ooler.Ooler) -> None:
     async with mqtt.filtered_messages(message_filter) as messages:
         async for message in messages:
             temperature = int(float(message.payload.decode()))
-            myooler.desired_temperature_c = temperature
+            await myooler.set_desired_temperature_c(temperature)
             await send_update(mqtt, myooler)
 
 
@@ -120,9 +121,9 @@ async def control_power(mqtt: Client, myooler: ooler.Ooler) -> None:
     async with mqtt.filtered_messages(message_filter) as messages:
         async for message in messages:
             if message.payload.decode() == "off":
-                myooler.powered_on = False
+                await myooler.set_power_state(False)
             elif message.payload.decode() == "auto":
-                myooler.powered_on = True
+                await myooler.set_power_state(True)
 
             await send_update(mqtt, myooler)
 
@@ -137,16 +138,16 @@ async def send_update_loop(mqtt: Client, myooler: ooler.Ooler) -> None:
 async def send_update(mqtt: Client, myooler: ooler.Ooler) -> None:
     """Send a single update message"""
     power = "off"
-    if myooler.powered_on is True:
+    if await myooler.powered_on() is True:
         power = "auto"
 
     state_payload = {
         "power": power,
-        "current_temperature": myooler.actual_temperature_c,
-        "desired_temperature": myooler.desired_temperature_c,
-        "fan_mode": (myooler.fan_speed).name,
-        "water_level": myooler.water_level,
-        "cleaning": myooler.cleaning,
+        "current_temperature": await myooler.get_actual_temperature_c(),
+        "desired_temperature": await myooler.get_desired_temperature_c(),
+        "fan_mode": (await myooler.get_fan_speed()).name,
+        "water_level": await myooler.get_water_level(),
+        "cleaning": await myooler.is_cleaning(),
     }
 
     topic = f"ooler/{sanitise_mac(myooler.address)}/state"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 asyncio_mqtt>=0.12.1
-gattlib>=0.20201113
 PyYAML>=5.3
+bleak>=0.18.0


### PR DESCRIPTION
gattlib isn't particularly actively developed and I have issues with it on my Pi. Bleak is an async BLE library that is actively maintained, and that is used by Home Assistant. I _also_ have issues with it on my Pi, but this PR will be merged when I've sorted that (quite possibly the next major Debian release).