### PR TITLE
Add MQTT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ I have had issues with Python segfaulting, so I'm not able to properly handle
 all errors, and so I'm running this with it set to restart when it falls over.
 I would advise running it like this, e.g. with systemd.
 
-This only works with unencrypted and unauthenticated MQTT brokers - I imagine
-support shouldn't be too hard to add, it's just not something I need at the
-moment.
+This only works with unencrypted MQTT brokers - I imagine support shouldn't be
+too hard to add, it's just not something I need at the moment.
 
 The Ooler works in Fahrenheit internally, so the Celsius mappings are a bit
 clunky (and greater than the amount of precision allowed by the device). This

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -66,8 +66,8 @@ async def main():
 
     async with Client(
         hostname=config["mqtt_broker"],
-        username=config["mqtt_username"],
-        password=config["mqtt_password"]) as mqtt:
+        username=config["mqtt_username"] if "mqtt_username" in config else None,
+        password=config["mqtt_password"] if "mqtt_password" in config else None) as mqtt:
         for topic, payload in cfg_payloads.items():
             await mqtt.publish(topic, json.dumps(payload), retain=True)
         await mqtt.subscribe(f"ooler/{sanitise_mac(myooler.address)}/+/set")

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -64,7 +64,10 @@ async def main():
         },
     }
 
-    async with Client(config["mqtt_broker"]) as mqtt:
+    async with Client(
+        hostname=config["mqtt_broker"],
+        username=config["mqtt_username"],
+        password=config["mqtt_password"]) as mqtt:
         for topic, payload in cfg_payloads.items():
             await mqtt.publish(topic, json.dumps(payload), retain=True)
         await mqtt.subscribe(f"ooler/{sanitise_mac(myooler.address)}/+/set")

--- a/ooler_mqtt_bridge.yaml.example
+++ b/ooler_mqtt_bridge.yaml.example
@@ -7,3 +7,6 @@ mqtt_broker: mosquitto
 homeassistant_prefix: homeassistant
 # How often to send periodic updates, in seconds
 update_interval: 60
+# Login information to authenticate to MQTT
+mqtt_username: username
+mqtt_password: password


### PR DESCRIPTION
The Home Assistant Mosquitto addon requires authentication by default, and for me adding this support is easier than turning that off :)

Tested with the config set, against a broker with auth required and a broker with auth not required. Mosquitto at least does not complain if you connect using authentication to a broker which does not require it.