### PR TITLE
Improve reliability of Bleak connection

### DIFF
--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -8,7 +8,7 @@ import asyncio
 class Ooler:
     """Control an Ooler device via Bluetooth LE"""
 
-    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=1):
+    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=5):
         self.address = address
         self.stay_connected = stay_connected
         self.max_connection_attempts = max_connection_attempts

--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -8,7 +8,7 @@ import asyncio
 class Ooler:
     """Control an Ooler device via Bluetooth LE"""
 
-    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=5):
+    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=1):
         self.address = address
         self.stay_connected = stay_connected
         self.max_connection_attempts = max_connection_attempts

--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -38,7 +38,7 @@ class Ooler:
                     self.logger.info(f"Connected to {self.address}")
                 except BleakError as exc:
                     self.logger.warning(f"Failed to connect on attempt {attempt}, got {exc}")
-                    asyncio.sleep(self.connection_retry_interval)
+                    await asyncio.sleep(self.connection_retry_interval)
                 attempt = attempt + 1
 
             if not self.client.is_connected:

--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -2,17 +2,18 @@
 import logging
 from ooler import constants
 from bleak import BleakClient, BleakError
-import time
+import asyncio
 from threading import Lock
 
 
 class Ooler:
     """Control an Ooler device via Bluetooth LE"""
 
-    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30):
+    def __init__(self, address=None, stay_connected=True, max_connection_attempts=30, connection_retry_interval=1):
         self.address = address
         self.stay_connected = stay_connected
         self.max_connection_attempts = max_connection_attempts
+        self.connection_retry_interval = connection_retry_interval
         self.client = BleakClient(self.address)
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.DEBUG)
@@ -34,7 +35,7 @@ class Ooler:
                     self.logger.info(f"Connected to {self.address}")
                 except BleakError as exc:
                     self.logger.warning(f"Failed to connect on attempt {attempt}, got {exc}")
-                    time.sleep(1)
+                    asyncio.sleep(self.connection_retry_interval)
                 attempt = attempt + 1
 
             if not self.client.is_connected:


### PR DESCRIPTION
- Add retries to the Bleak BLE connection, since for me it usually fails 5-10 times. (This explains why the phone app takes so long to connect too!)
- Add locking on the connection attempt. I was experiencing cases where multiple requests came in over MQTT, triggering multiple connection attempts, which would then "deadlock" because BlueZ would say an operation was already in progress and kill all ongoing attempts.

(Note the target of this PR is the `feature/switch_to_bleak` branch. If that gets merged without these changes, this PR should be changed to point to `main`)