### PR TITLE
Enable native control in Fahrenheit

### DIFF
--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -92,6 +92,7 @@ async def control_temperature(mqtt: Client, myooler: ooler.Ooler) -> None:
                     await myooler.set_desired_temperature_f(temperature)
                 else:
                     await myooler.set_desired_temperature_c(temperature)
+                await send_update(mqtt, myooler)
 
 
 async def control_power(mqtt: Client, myooler: ooler.Ooler) -> None:

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -139,8 +139,8 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
             "device": device_definition,
             "fan_modes": ["Silent", "Regular", "Boost"],
             "icon": "mdi:bed",
-            "max_temp": 115 if temp_unit is constants.TemperatureUnit.Fahrenheit else 47,
-            "min_temp": 47 if temp_unit is constants.TemperatureUnit.Fahrenheit else 12,
+            "max_temp": 120 if temp_unit is constants.TemperatureUnit.Fahrenheit else 47,
+            "min_temp": 45 if temp_unit is constants.TemperatureUnit.Fahrenheit else 12,
         },
         f"{config['homeassistant_prefix']}/sensor/{sanitise_mac(myooler.address)}_water_level/config": {
             "name": "Water Level",

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -87,8 +87,11 @@ async def control_temperature(mqtt: Client, myooler: ooler.Ooler) -> None:
         async for message in messages:
             if message.topic.matches(message_filter):
                 temperature = int(float(message.payload.decode()))
-                await myooler.set_desired_temperature_c(temperature)
-                await send_update(mqtt, myooler)
+                temp_unit = await myooler.get_temperature_unit()
+                if temp_unit is constants.TemperatureUnit.Fahrenheit:
+                    await myooler.set_desired_temperature_f(temperature)
+                else:
+                    await myooler.set_desired_temperature_c(temperature)
 
 
 async def control_power(mqtt: Client, myooler: ooler.Ooler) -> None:
@@ -114,6 +117,7 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
         "suggested_area": "Bedroom",
     }
 
+    temp_unit = await myooler.get_temperature_unit();
     cfg_payloads = {
         f"{config['homeassistant_prefix']}/climate/{sanitise_mac(myooler.address)}/config": {
             "name": await myooler.get_name(),
@@ -129,14 +133,14 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
             "mode_command_topic": f"ooler/{sanitise_mac(myooler.address)}/power/set",
             "temperature_command_topic": f"ooler/{sanitise_mac(myooler.address)}/temperature/set",
             "modes": ["auto", "off"],
-            "temperature_unit": "C",
+            "temperature_unit": "F" if temp_unit is constants.TemperatureUnit.Fahrenheit else "C",
             "temp_step": 1,
             "unique_id": myooler.address,
             "device": device_definition,
             "fan_modes": ["Silent", "Regular", "Boost"],
             "icon": "mdi:bed",
-            "max_temp": 47,
-            "min_temp": 12,
+            "max_temp": 115 if temp_unit is constants.TemperatureUnit.Fahrenheit else 47,
+            "min_temp": 47 if temp_unit is constants.TemperatureUnit.Fahrenheit else 12,
         },
         f"{config['homeassistant_prefix']}/sensor/{sanitise_mac(myooler.address)}_water_level/config": {
             "name": "Water Level",
@@ -196,10 +200,20 @@ async def send_update(mqtt: Client, myooler: ooler.Ooler) -> None:
     if await myooler.powered_on() is True:
         power = "auto"
 
+    temp_unit = await myooler.get_temperature_unit()
+    current_temperature: int = None
+    desired_temperature: int = None
+    if temp_unit is constants.TemperatureUnit.Fahrenheit:
+        current_temperature = await myooler.get_actual_temperature_f()
+        desired_temperature = await myooler.get_desired_temperature_f()
+    else:
+        current_temperature = await myooler.get_actual_temperature_c()
+        desired_temperature = await myooler.get_desired_temperature_c()
+
     state_payload = {
         "power": power,
-        "current_temperature": await myooler.get_actual_temperature_c(),
-        "desired_temperature": await myooler.get_desired_temperature_c(),
+        "current_temperature": current_temperature,
+        "desired_temperature": desired_temperature,
         "fan_mode": (await myooler.get_fan_speed()).name,
         "water_level": await myooler.get_water_level(),
         "cleaning": await myooler.is_cleaning(),


### PR DESCRIPTION
With Home Assistant set to Fahrentheit, and the Ooler set to Fahrentheit, there would be an annoying amount of precision lost with commands in F coming from me to Home Assistant, Home Assistant converting that to C, to send over MQTT, then this bridge converting back from C to F to send to the Ooler.

This PR enables natively controlling the Ooler in the units it is displaying.