### PR TITLE
Enable configuring Ooler's temperature units

### DIFF
--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -151,6 +151,11 @@ class Ooler:
             )
         return self.device_temperature_unit
 
+    async def set_temperature_unit(self, unit: constants.TemperatureUnit):
+        await self._write_characteristic(
+            constants.DISPLAY_TEMPERATURE_UNIT, unit.value.to_bytes(1, byteorder="big"))
+        self.device_temperature_unit = unit
+
     async def get_fan_speed(self) -> constants.FanSpeed:
         """Return the fan mode of the Ooler"""
         speed = await self._request_characteristic(constants.FAN_SPEED)

--- a/ooler/ooler.py
+++ b/ooler/ooler.py
@@ -154,7 +154,9 @@ class Ooler:
     async def set_temperature_unit(self, unit: constants.TemperatureUnit):
         await self._write_characteristic(
             constants.DISPLAY_TEMPERATURE_UNIT, unit.value.to_bytes(1, byteorder="big"))
-        self.device_temperature_unit = unit
+        # Refresh the cached value
+        self.device_temperature_unit = None
+        await self.get_temperature_unit()
 
     async def get_fan_speed(self) -> constants.FanSpeed:
         """Return the fan mode of the Ooler"""

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -66,6 +66,19 @@ async def main():
             "payload_on": True,
             "payload_off": False,
         },
+        f"{config['homeassistant_prefix']}/select/{sanitise_mac(myooler.address)}_temp_units/config": {
+            "name": "Device Temperature Units",
+            "state_topic": f"ooler/{sanitise_mac(myooler.address)}/state",
+            "command_topic": f"ooler/{sanitise_mac(myooler.address)}/temp_units/set",
+            "value_template": "{{ value_json.temp_units }}",
+            "unique_id": f"{myooler.address}_temp_units",
+            "device": device_definition,
+            "enabled_by_default": False,
+            "options": [
+                constants.TemperatureUnit.Celsius.name,
+                constants.TemperatureUnit.Fahrenheit.name
+                ],
+        },
     }
 
     while True:
@@ -83,6 +96,7 @@ async def main():
                     tg.create_task(control_fan(mqtt, myooler))
                     tg.create_task(control_temperature(mqtt, myooler))
                     tg.create_task(control_cleaning(mqtt, myooler))
+                    tg.create_task(control_device_units(mqtt, myooler))
                     tg.create_task(send_update_loop(mqtt, myooler))
                     # This will never return gracefully, but might bubble out if a task has an exception
         except aiomqtt.MqttError as error:
@@ -111,6 +125,17 @@ async def control_cleaning(mqtt: Client, myooler: ooler.Ooler) -> None:
         async for message in messages:
             payload = message.payload.decode()
             await myooler.set_cleaning(payload == "True")
+            await send_update(mqtt, myooler)
+
+
+async def control_device_units(mqtt: Client, myooler: ooler.Ooler) -> None:
+    """Watch for and act on instructions to change the device units"""
+    message_filter = f"ooler/{sanitise_mac(myooler.address)}/temp_units/set"
+    async with mqtt.filtered_messages(message_filter) as messages:
+        async for message in messages:
+            payload = message.payload.decode()
+            new_units = constants.TemperatureUnit[payload]
+            await myooler.set_temperature_unit(new_units)
             await send_update(mqtt, myooler)
 
 
@@ -157,6 +182,7 @@ async def send_update(mqtt: Client, myooler: ooler.Ooler) -> None:
         "fan_mode": (await myooler.get_fan_speed()).name,
         "water_level": await myooler.get_water_level(),
         "cleaning": await myooler.is_cleaning(),
+        "temp_units": (await myooler.get_temperature_unit()).name,
     }
 
     topic = f"ooler/{sanitise_mac(myooler.address)}/state"

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -18,13 +18,6 @@ async def main():
     myooler = ooler.Ooler(address=config["ooler_mac"], stay_connected=True)
     await myooler.connect()
 
-    device_definition = {
-        "connections": [("mac", myooler.address)],
-        "model": "Ooler",
-        "manufacturer": "chilisleep",
-        "suggested_area": "Bedroom",
-    }
-
     while True:
         reconnect_interval = 5
         try:
@@ -108,6 +101,13 @@ async def control_power(mqtt: Client, myooler: ooler.Ooler) -> None:
 
 async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, str]]:
     """Return the discovery payloads for the device"""
+    device_definition = {
+        "connections": [("mac", myooler.address)],
+        "model": "Ooler",
+        "manufacturer": "chilisleep",
+        "suggested_area": "Bedroom",
+    }
+
     cfg_payloads = {
         f"{config['homeassistant_prefix']}/climate/{sanitise_mac(myooler.address)}/config": {
             "name": await myooler.get_name(),

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -10,6 +10,7 @@ from ooler import constants
 import ooler
 import logging
 
+from typing import Dict
 
 async def main():
     logger = logging.getLogger(__name__)
@@ -24,6 +25,89 @@ async def main():
         "suggested_area": "Bedroom",
     }
 
+    while True:
+        reconnect_interval = 5
+        try:
+            async with Client(
+                hostname=config["mqtt_broker"],
+                username=config["mqtt_username"] if "mqtt_username" in config else None,
+                password=config["mqtt_password"] if "mqtt_password" in config else None) as mqtt:
+                await send_discovery(mqtt, myooler)
+                await mqtt.subscribe(f"ooler/{sanitise_mac(myooler.address)}/+/set")
+                async with asyncio.TaskGroup() as tg:
+                    tg.create_task(control_power(mqtt, myooler))
+                    tg.create_task(control_fan(mqtt, myooler))
+                    tg.create_task(control_temperature(mqtt, myooler))
+                    tg.create_task(control_cleaning(mqtt, myooler))
+                    tg.create_task(control_device_units(mqtt, myooler))
+                    tg.create_task(send_update_loop(mqtt, myooler))
+                    # This will never return gracefully, but might bubble out if a task has an exception
+        except aiomqtt.MqttError as error:
+            logger.warning(f'Error "{error}". Reconnecting in {reconnect_interval} seconds.')
+            await asyncio.sleep(reconnect_interval)
+
+def sanitise_mac(mac: str) -> str:
+    """Clean up a MAC so it's suitable for use where colons aren't"""
+    return mac.replace(":", "_")
+
+
+async def control_fan(mqtt: Client, myooler: ooler.Ooler) -> None:
+    """Watch for and act on fan control messages"""
+    message_filter = f"ooler/{sanitise_mac(myooler.address)}/fan/set"
+    async with mqtt.filtered_messages(message_filter) as messages:
+        async for message in messages:
+            fan_speed = message.payload.decode()
+            await myooler.set_fan_speed(constants.FanSpeed[fan_speed])
+            await send_update(mqtt, myooler)
+
+
+async def control_cleaning(mqtt: Client, myooler: ooler.Ooler) -> None:
+    """Watch for and act on instructions to start cleaning"""
+    message_filter = f"ooler/{sanitise_mac(myooler.address)}/cleaning/set"
+    async with mqtt.filtered_messages(message_filter) as messages:
+        async for message in messages:
+            payload = message.payload.decode()
+            await myooler.set_cleaning(payload == "True")
+            await send_update(mqtt, myooler)
+
+
+async def control_device_units(mqtt: Client, myooler: ooler.Ooler) -> None:
+    """Watch for and act on instructions to change the device units"""
+    message_filter = f"ooler/{sanitise_mac(myooler.address)}/temp_units/set"
+    async with mqtt.filtered_messages(message_filter) as messages:
+        async for message in messages:
+            payload = message.payload.decode()
+            new_units = constants.TemperatureUnit[payload]
+            await myooler.set_temperature_unit(new_units)
+            await send_discovery(mqtt, myooler)
+            await send_update(mqtt, myooler)
+
+
+async def control_temperature(mqtt: Client, myooler: ooler.Ooler) -> None:
+    """Watch for and act on temperature control messages"""
+    message_filter = f"ooler/{sanitise_mac(myooler.address)}/temperature/set"
+    async with mqtt.filtered_messages(message_filter) as messages:
+        async for message in messages:
+            temperature = int(float(message.payload.decode()))
+            await myooler.set_desired_temperature_c(temperature)
+            await send_update(mqtt, myooler)
+
+
+async def control_power(mqtt: Client, myooler: ooler.Ooler) -> None:
+    """Watch for and act on power control messages"""
+    message_filter = f"ooler/{sanitise_mac(myooler.address)}/power/set"
+    async with mqtt.filtered_messages(message_filter) as messages:
+        async for message in messages:
+            if message.payload.decode() == "off":
+                await myooler.set_power_state(False)
+            elif message.payload.decode() == "auto":
+                await myooler.set_power_state(True)
+
+            await send_update(mqtt, myooler)
+
+
+async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, str]]:
+    """Return the discovery payloads for the device"""
     cfg_payloads = {
         f"{config['homeassistant_prefix']}/climate/{sanitise_mac(myooler.address)}/config": {
             "name": await myooler.get_name(),
@@ -80,86 +164,17 @@ async def main():
                 ],
         },
     }
-
-    while True:
-        reconnect_interval = 5
-        try:
-            async with Client(
-                hostname=config["mqtt_broker"],
-                username=config["mqtt_username"] if "mqtt_username" in config else None,
-                password=config["mqtt_password"] if "mqtt_password" in config else None) as mqtt:
-                for topic, payload in cfg_payloads.items():
-                    await mqtt.publish(topic, json.dumps(payload), retain=True)
-                await mqtt.subscribe(f"ooler/{sanitise_mac(myooler.address)}/+/set")
-                async with asyncio.TaskGroup() as tg:
-                    tg.create_task(control_power(mqtt, myooler))
-                    tg.create_task(control_fan(mqtt, myooler))
-                    tg.create_task(control_temperature(mqtt, myooler))
-                    tg.create_task(control_cleaning(mqtt, myooler))
-                    tg.create_task(control_device_units(mqtt, myooler))
-                    tg.create_task(send_update_loop(mqtt, myooler))
-                    # This will never return gracefully, but might bubble out if a task has an exception
-        except aiomqtt.MqttError as error:
-            logger.warning(f'Error "{error}". Reconnecting in {reconnect_interval} seconds.')
-            await asyncio.sleep(reconnect_interval)
-
-def sanitise_mac(mac: str) -> str:
-    """Clean up a MAC so it's suitable for use where colons aren't"""
-    return mac.replace(":", "_")
+    return cfg_payloads
 
 
-async def control_fan(mqtt: Client, myooler: ooler.Ooler) -> None:
-    """Watch for and act on fan control messages"""
-    message_filter = f"ooler/{sanitise_mac(myooler.address)}/fan/set"
-    async with mqtt.filtered_messages(message_filter) as messages:
-        async for message in messages:
-            fan_speed = message.payload.decode()
-            await myooler.set_fan_speed(constants.FanSpeed[fan_speed])
-            await send_update(mqtt, myooler)
-
-
-async def control_cleaning(mqtt: Client, myooler: ooler.Ooler) -> None:
-    """Watch for and act on instructions to start cleaning"""
-    message_filter = f"ooler/{sanitise_mac(myooler.address)}/cleaning/set"
-    async with mqtt.filtered_messages(message_filter) as messages:
-        async for message in messages:
-            payload = message.payload.decode()
-            await myooler.set_cleaning(payload == "True")
-            await send_update(mqtt, myooler)
-
-
-async def control_device_units(mqtt: Client, myooler: ooler.Ooler) -> None:
-    """Watch for and act on instructions to change the device units"""
-    message_filter = f"ooler/{sanitise_mac(myooler.address)}/temp_units/set"
-    async with mqtt.filtered_messages(message_filter) as messages:
-        async for message in messages:
-            payload = message.payload.decode()
-            new_units = constants.TemperatureUnit[payload]
-            await myooler.set_temperature_unit(new_units)
-            await send_update(mqtt, myooler)
-
-
-async def control_temperature(mqtt: Client, myooler: ooler.Ooler) -> None:
-    """Watch for and act on temperature control messages"""
-    message_filter = f"ooler/{sanitise_mac(myooler.address)}/temperature/set"
-    async with mqtt.filtered_messages(message_filter) as messages:
-        async for message in messages:
-            temperature = int(float(message.payload.decode()))
-            await myooler.set_desired_temperature_c(temperature)
-            await send_update(mqtt, myooler)
-
-
-async def control_power(mqtt: Client, myooler: ooler.Ooler) -> None:
-    """Watch for and act on power control messages"""
-    message_filter = f"ooler/{sanitise_mac(myooler.address)}/power/set"
-    async with mqtt.filtered_messages(message_filter) as messages:
-        async for message in messages:
-            if message.payload.decode() == "off":
-                await myooler.set_power_state(False)
-            elif message.payload.decode() == "auto":
-                await myooler.set_power_state(True)
-
-            await send_update(mqtt, myooler)
+async def send_discovery(mqtt: Client, myooler: ooler.Ooler) -> None:
+    """(Re-)send the device discovery payload
+        This is needed when changing values in the payload,
+        such as the device temperature units.
+    """
+    cfg_payloads = await get_discovery_payloads(myooler)
+    for topic, payload in cfg_payloads.items():
+        await mqtt.publish(topic, json.dumps(payload), retain=True)
 
 
 async def send_update_loop(mqtt: Client, myooler: ooler.Ooler) -> None:


### PR DESCRIPTION
The Ooler natively supports either Centigrade or Fahrenheit, and accepts commands to switch between them.

This PR adds a `select` entity to the exposed Ooler device, enabling switching the operating units of the device.

The `select` element looks kind of sloppy in HA, but I haven't seen a better device type this control. Ideally it would be a native part of the `climate` device, but it is not.

![Screenshot_20231103_202135_Home Assistant](https://github.com/turmoni/ooler-mqtt-bridge/assets/1900703/5f239d48-7dbb-4142-aba8-66cddd6c3c8b)
