### PR TITLE
Add the ability to set the time of the Ooler

### DIFF
--- a/ooler/constants.py
+++ b/ooler/constants.py
@@ -1,5 +1,6 @@
 """Constants to refer to the UUIDs for Ooler characteristics"""
 from enum import Enum
+from bleak import uuids
 
 TARGET_TEMP_F = "6aa46711-a29d-4f8a-88e2-044ca1fd03ff"
 ACTUAL_TEMP = "e8ebded3-9dca-45c2-a2d8-ceffb901474d"
@@ -20,6 +21,8 @@ LIFETIME = "5d30781f-1d06-4790-bbb8-5e1d7da96383"
 RUNTIME = "1a5c6dae-34de-4265-9fa6-0a59f7f683ee"
 UV_RUNTIME = "0ab6ff00-8d1b-475e-bcfa-ed3467f1f890"
 DISPLAY_TEMPERATURE_UNIT = "2c988613-fe15-4067-85bc-8e59d5e0b1e3"
+LOCAL_TIME = uuids.normalize_uuid_str("2A0F")
+CURRENT_TIME = uuids.normalize_uuid_str("2A2B")
 
 
 class TemperatureUnit(Enum):

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -18,6 +18,9 @@ async def main():
     myooler = ooler.Ooler(address=config["ooler_mac"], stay_connected=True)
     await myooler.connect()
 
+    if "tz" in config:
+        await myooler.set_current_time(config["tz"])
+
     while True:
         reconnect_interval = 5
         try:


### PR DESCRIPTION
I am not entirely confident that this won't break things, hence it being on its own branch for me to play with and test for a while to see what happens. The data I was getting back from the Current Time Service in its initial state was... weird, which is what makes me a bit apprehensive here, but I'll see if it messes up any of my schedules or not.

To use this, add a "tz" option to the config YAML file with your local timezone (in [ZoneInfo form](https://docs.python.org/3/library/zoneinfo.html#module-zoneinfo), e.g. "Europe/London" for me).