### PR TITLE
Parameterize service files for multi-device control

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,3 @@ The Ooler works in Fahrenheit internally, so the Celsius mappings are a bit
 clunky (and greater than the amount of precision allowed by the device). This
 is also true of the app. The underlying library allows for control via
 Fahrenheit, but the bridge only supports Celsius.
-
-I have only been able to test this on one device, so I don't know if there are
-any differences between different setups. This also only supports one device
-being configured, again, because I only have the one so wouldn't be able to use
-or test supporting more than one.

--- a/ooler_mqtt_bridge.service
+++ b/ooler_mqtt_bridge.service
@@ -1,3 +1,10 @@
+# Ooler MQTT service for a single device
+# To set up your environment:
+# - Install dependencies (pip install -r requirements.txt`)
+# - Put your config file into /etc/
+# - Install this service file (into /etc/systemd/system, or such)
+# - Enable your service, like `systemctl enable ooler_mqtt_bridge
+
 [Unit]
 Description=Ooler MQTT Bridge
 

--- a/ooler_mqtt_bridge.service
+++ b/ooler_mqtt_bridge.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Ooler MQTT Bridge
+
+[Service]
+WorkingDirectory=/usr/local/bin/
+ExecStart=/usr/local/bin/ooler_mqtt_bridge /etc/ooler_mqtt_bridge.yaml
+User=pi
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/ooler_mqtt_bridge@.service
+++ b/ooler_mqtt_bridge@.service
@@ -3,7 +3,7 @@
 # - Install dependencies (pip install -r requirements.txt`)
 # - Put your config file(s) into /etc/
 # - Install this service file (into /etc/systemd/system, or such)
-# - Enable your service(s) for each config file, like `systemctl enable ooler_mqtt_bridge_venv@ooler_mqtt_bridge_1.yml`
+# - Enable your service(s) for each config file, like `systemctl enable ooler_mqtt_bridge@ooler_mqtt_bridge_1.yml`
 
 [Unit]
 Description=Ooler MQTT Bridge

--- a/ooler_mqtt_bridge@.service
+++ b/ooler_mqtt_bridge@.service
@@ -1,3 +1,10 @@
+# Ooler MQTT service
+# To set up your environment:
+# - Install dependencies (pip install -r requirements.txt`)
+# - Put your config file(s) into /etc/
+# - Install this service file (into /etc/systemd/system, or such)
+# - Enable your service(s) for each config file, like `systemctl enable ooler_mqtt_bridge_venv@ooler_mqtt_bridge_1.yml`
+
 [Unit]
 Description=Ooler MQTT Bridge
 

--- a/ooler_mqtt_bridge@.service
+++ b/ooler_mqtt_bridge@.service
@@ -3,7 +3,7 @@ Description=Ooler MQTT Bridge
 
 [Service]
 WorkingDirectory=/usr/local/bin/
-ExecStart=/usr/local/bin/ooler_mqtt_bridge /etc/ooler_mqtt_bridge.yaml
+ExecStart=/usr/local/bin/ooler-mqtt-bridge /etc/%I
 User=pi
 Restart=always
 RestartSec=30

--- a/ooler_mqtt_bridge_venv@.service
+++ b/ooler_mqtt_bridge_venv@.service
@@ -1,5 +1,14 @@
+# Ooler MQTT service, using Python virtual env to contain dependencies.
+# To set up your environment:
+# - Add a virtual environment to your code directory, like `python3 -m venv env`
+# - Install dependencies in the venv (`source env/bin/activate && pip install -r requirements.txt`)
+# - Put your config file(s) into /etc/
+# - Link your code directory as /usr/local/bin/ooler-mqtt-bridge
+# - Install this service file (into /etc/systemd/system, or such)
+# - Enable your service(s) for each config file, like `systemctl enable ooler_mqtt_bridge_venv@ooler_mqtt_bridge_1.yml`
+
 [Unit]
-Description=Ooler MQTT Bridge
+Description=Ooler MQTT Bridge, using virtual environment
 
 [Service]
 WorkingDirectory=/usr/local/bin/ooler-mqtt-bridge

--- a/ooler_mqtt_bridge_venv@.service
+++ b/ooler_mqtt_bridge_venv@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Ooler MQTT Bridge
+
+[Service]
+WorkingDirectory=/usr/local/bin/ooler-mqtt-bridge
+ExecStart=/usr/local/bin/ooler-mqtt-bridge/env/bin/python ./ooler_mqtt_bridge /etc/%I
+User=pi
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Since the beginning (only a year ago?) I've been using this project with a parameterized service file to allow running two bridges to control my two Oolers. In the spirit of "getting all my private change out in the open", here is the change I have made.

The parameterized service file should be a drop-in replacement for anyone using the current model. Just disable your current service and remove the old file from systemd, then add this new file and add the new service, adding your config file name as the parameter.

Additionally, I have always used a virtual environment. I realize this is not for everyone, so I have added a second service file (which is the one I actually use) to use the virtual environment Python.

No hard feelings if you don't want these changes, or you only want part of them.