### PR TITLE
Send last will message when bridge process is shutting down

### DIFF
--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -28,7 +28,8 @@ async def main():
             async with Client(
                 hostname=config["mqtt_broker"],
                 username=config["mqtt_username"] if "mqtt_username" in config else None,
-                password=config["mqtt_password"] if "mqtt_password" in config else None) as mqtt:
+                password=config["mqtt_password"] if "mqtt_password" in config else None,
+                will=get_last_will(myooler)) as mqtt:
                 await send_discovery(mqtt, myooler)
                 await mqtt.subscribe(f"ooler/{sanitise_mac(myooler.address)}/+/set")
                 async with asyncio.TaskGroup() as tg:
@@ -44,6 +45,14 @@ async def main():
             await asyncio.sleep(reconnect_interval)
         except BaseException as error:
             logger.critical(f'Error "{error}".')
+            # Always send the last will message even if we are exiting "gracefully" with an exception
+            will: aiomqtt.Will = get_last_will(myooler)
+            async with Client(
+                hostname=config["mqtt_broker"],
+                username=config["mqtt_username"] if "mqtt_username" in config else None,
+                password=config["mqtt_password"] if "mqtt_password" in config else None,
+                will=will) as mqtt:
+                await mqtt.publish(will.topic, will.payload, retain=will.retain)
             raise
 
 
@@ -194,6 +203,16 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
         },
     }
     return cfg_payloads
+
+
+def get_last_will(myooler: ooler.Ooler) -> aiomqtt.Will:
+    """Return the last will message for the device"""
+    return aiomqtt.Will(
+        topic=get_status_topic(myooler),
+        payload="offline",
+        qos=0,
+        retain=True,
+    )
 
 
 def prepare_payload(payload: Any) -> str:

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -22,6 +22,8 @@ async def main():
     if "tz" in config:
         await myooler.set_current_time(config["tz"])
 
+    should_send_will = "send_will" in config and config["send_will"]
+
     while True:
         reconnect_interval = 5
         try:
@@ -29,7 +31,7 @@ async def main():
                 hostname=config["mqtt_broker"],
                 username=config["mqtt_username"] if "mqtt_username" in config else None,
                 password=config["mqtt_password"] if "mqtt_password" in config else None,
-                will=get_last_will(myooler)) as mqtt:
+                will=get_last_will(myooler) if should_send_will else None) as mqtt:
                 await send_discovery(mqtt, myooler)
                 await mqtt.subscribe(f"ooler/{sanitise_mac(myooler.address)}/+/set")
                 async with asyncio.TaskGroup() as tg:
@@ -45,14 +47,16 @@ async def main():
             await asyncio.sleep(reconnect_interval)
         except BaseException as error:
             logger.critical(f'Error "{error}".')
-            # Always send the last will message even if we are exiting "gracefully" with an exception
-            will: aiomqtt.Will = get_last_will(myooler)
-            async with Client(
-                hostname=config["mqtt_broker"],
-                username=config["mqtt_username"] if "mqtt_username" in config else None,
-                password=config["mqtt_password"] if "mqtt_password" in config else None,
-                will=will) as mqtt:
-                await mqtt.publish(will.topic, will.payload, retain=will.retain)
+
+            if should_send_will:
+                # Always send the last will message even if we are exiting "gracefully" with an exception
+                will: aiomqtt.Will = get_last_will(myooler)
+                async with Client(
+                    hostname=config["mqtt_broker"],
+                    username=config["mqtt_username"] if "mqtt_username" in config else None,
+                    password=config["mqtt_password"] if "mqtt_password" in config else None,
+                    will=will) as mqtt:
+                    await mqtt.publish(will.topic, will.payload, retain=will.retain)
             raise
 
 

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -116,6 +116,11 @@ async def control_power(mqtt: Client, myooler: ooler.Ooler) -> None:
                 await send_update(mqtt, myooler)
 
 
+def get_status_topic(myooler: ooler.Ooler) -> str:
+    """Get the status topic of the Ooler"""
+    return f"ooler/{sanitise_mac(myooler.address)}/status"
+
+
 async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, str]]:
     """Return the discovery payloads for the device"""
     device_definition = {
@@ -125,10 +130,13 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
         "suggested_area": "Bedroom",
     }
 
+    status_topic = get_status_topic(myooler)
     temp_unit = await myooler.get_temperature_unit();
     cfg_payloads = {
+        f"{status_topic}": "online",
         f"{config['homeassistant_prefix']}/climate/{sanitise_mac(myooler.address)}/config": {
             "name": await myooler.get_name(),
+            "availability_topic": status_topic,
             "mode_state_topic": f"ooler/{sanitise_mac(myooler.address)}/state",
             "mode_state_template": "{{ value_json.power }}",
             "current_temperature_topic": f"ooler/{sanitise_mac(myooler.address)}/state",
@@ -152,6 +160,7 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
         },
         f"{config['homeassistant_prefix']}/sensor/{sanitise_mac(myooler.address)}_water_level/config": {
             "name": "Water Level",
+            "availability_topic": status_topic,
             "state_topic": f"ooler/{sanitise_mac(myooler.address)}/state",
             "unit_of_measurement": "%",
             "value_template": "{{ value_json.water_level }}",
@@ -160,6 +169,7 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
         },
         f"{config['homeassistant_prefix']}/switch/{sanitise_mac(myooler.address)}_cleaning/config": {
             "name": "UV Cleaning",
+            "availability_topic": status_topic,
             "state_topic": f"ooler/{sanitise_mac(myooler.address)}/state",
             "command_topic": f"ooler/{sanitise_mac(myooler.address)}/cleaning/set",
             "value_template": "{{ value_json.cleaning }}",
@@ -170,6 +180,7 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
         },
         f"{config['homeassistant_prefix']}/select/{sanitise_mac(myooler.address)}_temp_units/config": {
             "name": "Device Temperature Units",
+            "availability_topic": status_topic,
             "state_topic": f"ooler/{sanitise_mac(myooler.address)}/state",
             "command_topic": f"ooler/{sanitise_mac(myooler.address)}/temp_units/set",
             "value_template": "{{ value_json.temp_units }}",

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -41,6 +41,9 @@ async def main():
         except aiomqtt.MqttError as error:
             logger.warning(f'Error "{error}". Reconnecting in {reconnect_interval} seconds.')
             await asyncio.sleep(reconnect_interval)
+        except BaseException as error:
+            logger.critical(f'Error "{error}".')
+            raise
 
 
 def sanitise_mac(mac: str) -> str:

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -9,7 +9,7 @@ from aiomqtt import Client
 from ooler import constants
 import ooler
 import logging
-from typing import Dict
+from typing import Dict, Any
 
 
 async def main():
@@ -181,6 +181,14 @@ async def get_discovery_payloads(myooler: ooler.Ooler) -> Dict[str, Dict[str, st
     return cfg_payloads
 
 
+def prepare_payload(payload: Any) -> str:
+    """Prepare a payload for sending"""
+    if isinstance(payload, str):
+        # A raw string need not be converted to JSON
+        return payload
+    return json.dumps(payload)
+
+
 async def send_discovery(mqtt: Client, myooler: ooler.Ooler) -> None:
     """(Re-)send the device discovery payload
         This is needed when changing values in the payload,
@@ -188,7 +196,7 @@ async def send_discovery(mqtt: Client, myooler: ooler.Ooler) -> None:
     """
     cfg_payloads = await get_discovery_payloads(myooler)
     for topic, payload in cfg_payloads.items():
-        await mqtt.publish(topic, json.dumps(payload), retain=True)
+        await mqtt.publish(topic, prepare_payload(payload), retain=True)
 
 
 async def send_update_loop(mqtt: Client, myooler: ooler.Ooler) -> None:

--- a/ooler_mqtt_bridge
+++ b/ooler_mqtt_bridge
@@ -17,6 +17,7 @@ async def main():
     """Initiate and start the loop"""
     myooler = ooler.Ooler(address=config["ooler_mac"], stay_connected=True)
     await myooler.connect()
+    logger.info(f"Successfully connected to ooler {myooler.address}.")
 
     if "tz" in config:
         await myooler.set_current_time(config["tz"])

--- a/ooler_mqtt_bridge.yaml.example
+++ b/ooler_mqtt_bridge.yaml.example
@@ -10,3 +10,5 @@ update_interval: 60
 # Login information to authenticate to MQTT
 mqtt_username: username
 mqtt_password: password
+# Flag controlling whether or not to send last will messages
+send_will: true


### PR DESCRIPTION
My Oolers seem to stop listening for Bluetooth connections whenever they lose power. I usually don't notice this is a problem until I wake up too hot in the middle of the night.

This PR adds the `will` field to the MQTT connection, meaning an ungraceful death of the client will be handled. Additionally, we manually send the same `will` message when the client is gracefully exiting, since the MQTT spec says a graceful disconnection should not trigger the `will` message.