### PR TITLE
Bump required Bleak version for normalize_uuid_str

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiomqtt>=1.2.1
 PyYAML>=5.3
-bleak>=0.18.0
+bleak>=0.20.0


### PR DESCRIPTION
#11 added a call to normalize_uuid_str, which was added in Bleak 0.20: https://bleak.readthedocs.io/en/latest/api/index.html?highlight=normalize_uuid_str#bleak.uuids.normalize_uuid_str

Update the requirements.txt for this new dependency version